### PR TITLE
Enable CD for plugin release

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,4 +95,3 @@ Any and all contributions welcome!
 ## License
 
 Licensed under MIT, see [LICENSE](LICENSE.md)
-


### PR DESCRIPTION
I accidentally committed the changes to enable CD directly into the main branch [here](https://github.com/jenkinsci/add-changes-to-build-changelog-plugin/commit/52143042f0e2665e35c51a1ae8df703d5554228f).  This pull request just contains a dummy commit to trigger the proper release workflow.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
